### PR TITLE
Some small improvements..

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ typedef map<string,float> Constants;
 
 vector<string>    rulesContainer = {"F -> F[+F][-F]"};
 string            axiom = "F";
-bool              randomZRotation = false;
+bool              randomYRotation = false;
 int               depth = 1;
 float             theta = 25.00;
 float             stepWidth = 10.00;
@@ -71,7 +71,7 @@ you can overwrite the default parameters using these methods:
 void setAxiom(string _axiom);
 void setRules(vector<string> _rulesContainer);
 void setTheta(float _theta);
-void setRandomZRotation(bool _randomZRotation);
+void setRandomZRotation(bool _randomYRotation);
 void setStep(int _depth);
 void setScaleWidth(bool _scaleWidht);
 void setStepWidth(float _stepWidth);

--- a/src/ofxLSystem.cpp
+++ b/src/ofxLSystem.cpp
@@ -29,7 +29,6 @@ void ofxLSystem::build(){
     }
     //clear the mesh
     mesh.clear();
-    normalsMesh.clear();
 
     // setup the turtle, the sentences and the geometry
     setMeshMode(geometry);
@@ -39,9 +38,10 @@ void ofxLSystem::build(){
 
     // populate the mesh
     turtle.generate(mesh, sentences.back(), depth);
-    getMesh() = mesh;
+    getMesh().clear();
+    getMesh().append(mesh);
     setBoundingBox(turtle.getBuildedBoundingBox());
-    //getMesh().enableNormals(); it does not work
+    getMesh().enableNormals();
 }
 
 void ofxLSystem::save(string filename){
@@ -66,42 +66,6 @@ void ofxLSystem::setMeshMode(ofxLSGeometryAvailable _geometry){
             mesh.setMode(OF_PRIMITIVE_TRIANGLES);
             break;
     }
-}
-
-//this code is copy&pastef from of3DPrimitive
-void ofxLSystem::drawNormals(float length, bool bFaceNormals) const{
-    const vector<ofVec3f>& normals    = mesh.getNormals();
-    const vector<ofVec3f>& vertices   = mesh.getVertices();
-    ofVec3f normal;
-    ofVec3f vert;
-
-    normalsMesh.setMode( OF_PRIMITIVE_LINES );
-    normalsMesh.getVertices().resize( normals.size() * 2);
-
-    if (bFaceNormals) {
-        for(int i = 0; i < (int)normals.size(); i++ ) {
-            if(i % 3 == 0) {
-                vert = (vertices[i]+vertices[i+1]+vertices[i+2]) / 3;
-            } else if (i % 3 == 1) {
-                vert = (vertices[i-1]+vertices[i]+vertices[i+1]) / 3;
-            } else if ( i % 3 == 2) {
-                vert = (vertices[i-2]+vertices[i-1]+vertices[i]) / 3;
-            }
-            normalsMesh.setVertex(i*2, vert);
-            normal = normals[i].getNormalized();
-            normal *= length;
-            normalsMesh.setVertex(i*2+1, normal+vert);
-        }
-    } else {
-        for(int i = 0; i < (int)normals.size(); i++) {
-            vert = vertices[i];
-            normal = normals[i].getNormalized();
-            normalsMesh.setVertex( i*2, vert);
-            normal *= length;
-            normalsMesh.setVertex(i*2+1, normal+vert);
-        }
-    }
-    normalsMesh.draw();
 }
 
 bool ofxLSystem::isAxiomInRules(string _axiom, vector<string> _rulesContainer){

--- a/src/ofxLSystem.h
+++ b/src/ofxLSystem.h
@@ -33,9 +33,7 @@ public:
 
     void build();
     void save(string filename);
-    // i've to redifine this method because i can not get it working
-    // that one inherited from of3DPrimive, i get this warning of3dPrimitive: drawNormals(): mesh normals are disabled
-    void drawNormals( float length, bool bFaceNormals=false ) const;
+
 private:
 
     vector<string>    rulesContainer = {"F -> F[+F][-F]"};
@@ -52,7 +50,6 @@ private:
     map<string,float> constants = Constants();
     ofxLSTurtle       turtle;
     ofVboMesh         mesh;
-    mutable ofMesh    normalsMesh;
     BoundingBox       boundingBox;
 
     void              setMeshMode(ofxLSGeometryAvailable geometry);


### PR DESCRIPTION
I'm really enjoying playing with this these plugins! In this PR:
- Fix Mesh normals issue and remove duplicate drawNormals definition. 
- Correct variable/method names on README.md.

With the mesh normals, it seems as though the mesh expects new meshes to be added using the `.append` method. [ofMesh.inl](https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/3d/ofMesh.inl#L1001) seems to be doing a lot of things that isn't just reassigning the mesh. I get consistent normals results with this change as I had before this change. However, before I was experiencing the normals not updating with the mesh's rotation/position and now they do. I'm also not getting any errors about normals being disabled. Also, I'm not sure what `normalsMesh` was doing and removing it didn't seem to break anything (it's only mentioned in the`ofxLSystem.cpp` and `ofxLSystem.h`). I assumed it was related to possible solutions to this normals bug. Let me know if I was wrong!

Thanks for all the work you've put into this.